### PR TITLE
feat: list products

### DIFF
--- a/list-products/index.html
+++ b/list-products/index.html
@@ -1,10 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Lista de Produtos</title>
   </head>
   <body>
     <div id="root"></div>

--- a/list-products/src/App.tsx
+++ b/list-products/src/App.tsx
@@ -1,34 +1,18 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { products, formatPrice } from './products'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <main>
+      <h1>Produtos</h1>
+      <ul>
+        {products.map((product) => (
+          <li key={product.id}>
+            {product.name} - {formatPrice(product.price)}
+          </li>
+        ))}
+      </ul>
+    </main>
   )
 }
 

--- a/list-products/src/products.ts
+++ b/list-products/src/products.ts
@@ -1,0 +1,18 @@
+export interface Product {
+  id: number
+  name: string
+  price: number
+}
+
+export const products: Product[] = [
+  { id: 1, name: 'Produto A', price: 29.9 },
+  { id: 2, name: 'Produto B', price: 59.9 },
+  { id: 3, name: 'Produto C', price: 99.9 }
+]
+
+export function formatPrice(value: number): string {
+  return value.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL'
+  })
+}


### PR DESCRIPTION
## Summary
- provide sample product dataset with price formatting
- render product list and localize page title in list-products
- restore original root ESLint config and remove workspace lint script

## Testing
- `pnpm --filter list-products lint`
- `pnpm --filter home lint`


------
https://chatgpt.com/codex/tasks/task_e_68c75b59456c8320b0e2c7280a676d22